### PR TITLE
Map Command keys to Ctrl for clipboard functionality in Wine

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ frozen. Let it finish. If it stalls, relaunch and it resumes.
 Everything lives in `~/Library/Application Support/Highball/`. Nothing touches `/usr` or
 `/Library`; deleting that folder is a full uninstall.
 
+⌘C / ⌘V / ⌘A work inside Windows apps — the Command keys are mapped to Ctrl, and Option to
+Alt so Alt-based game bindings keep working. Turn it off per bottle in settings for Wine's
+default, where Command acts as Alt.
+
 <details><summary>Prefer the terminal? The CLI does everything the app does.</summary>
 
 ```sh

--- a/Sources/HighballApp/AppState.swift
+++ b/Sources/HighballApp/AppState.swift
@@ -482,6 +482,7 @@ final class AppState {
             try await BottleStore.ensureWoW64(runner: runner, bottle: bottle, log: r.log)
             try? await runner.setGpuIdentity()
             try? await runner.setServiceTimeout()
+            try? await runner.setKeyboardMapping(commandIsControl: bottle.settings.commandIsControl)
             await MainActor.run { self.appendLog("bottle repaired — Windows environment refreshed") }
         }
     }

--- a/Sources/HighballApp/BottleView.swift
+++ b/Sources/HighballApp/BottleView.swift
@@ -365,6 +365,9 @@ struct BottleSettingsSheet: View {
                         ForEach(WindowsVersion.allCases, id: \.self) { Text($0.rawValue).tag($0) }
                     }
                     Toggle(L("Advertise AVX to games (Rosetta)"), isOn: binding(\.advertiseAVX))
+                    Toggle(L("Use ⌘C / ⌘V inside Windows apps"), isOn: binding(\.commandIsControl))
+                    Text(L("Maps the Command keys to Ctrl, so Mac copy and paste work in Steam and games. Option becomes Alt so Alt-based bindings keep working. Off = Wine's default, where Command acts as Alt."))
+                        .font(.caption).foregroundStyle(.secondary)
                     Text(L("Games run with the bottle’s sync (msync is fastest). Opening the Steam window restarts Windows processes with sync off — its interface needs it."))
                         .font(.caption).foregroundStyle(.secondary)
                 }

--- a/Sources/HighballApp/L10n.swift
+++ b/Sources/HighballApp/L10n.swift
@@ -10,6 +10,8 @@ func L(_ en: String) -> String {
 enum L10n {
     static let fr: [String: String] = [
         // Sidebar & shell
+        "Use ⌘C / ⌘V inside Windows apps": "Utiliser ⌘C / ⌘V dans les applications Windows",
+        "Maps the Command keys to Ctrl, so Mac copy and paste work in Steam and games. Option becomes Alt so Alt-based bindings keep working. Off = Wine's default, where Command acts as Alt.": "Associe les touches Command à Ctrl, pour que le copier-coller du Mac fonctionne dans Steam et les jeux. Option devient Alt afin que les raccourcis Alt continuent de fonctionner. Désactivé = comportement par défaut de Wine, où Command agit comme Alt.",
         "Bottles": "Bouteilles",
         "Engine": "Moteur",
         "New Bottle": "Nouvelle bouteille",

--- a/Sources/HighballKit/Bottle.swift
+++ b/Sources/HighballKit/Bottle.swift
@@ -219,6 +219,8 @@ public struct BottleSettings: Codable, Sendable {
         }
         dllOverrides = try c.decodeIfPresent(String.self, forKey: .dllOverrides) ?? ""
         dllOverridesSynced = try c.decodeIfPresent(String.self, forKey: .dllOverridesSynced)
+        commandIsControl = try c.decodeIfPresent(Bool.self, forKey: .commandIsControl) ?? true
+        commandIsControlSynced = try c.decodeIfPresent(Bool.self, forKey: .commandIsControlSynced)
         environment = try c.decodeIfPresent([String: String].self, forKey: .environment) ?? [:]
         pins = try c.decodeIfPresent([Pin].self, forKey: .pins) ?? []
         recipes = try c.decodeIfPresent([String].self, forKey: .recipes) ?? []

--- a/Sources/HighballKit/Bottle.swift
+++ b/Sources/HighballKit/Bottle.swift
@@ -165,6 +165,11 @@ public struct BottleSettings: Codable, Sendable {
     /// beeps instead of pasting. Option is mapped to Alt alongside it — without that, mapping both
     /// Command keys leaves no way to send Alt at all (winemac.drv warns about exactly this).
     public var commandIsControl: Bool = true
+    /// The commandIsControl value last mirrored into the prefix registry. Bottles created before
+    /// this setting existed carry nil, so the first launch after updating applies it — otherwise a
+    /// user would have to know to press Repair, which is exactly the discoverability problem this
+    /// setting exists to fix.
+    public var commandIsControlSynced: Bool?
     /// Windows UI scale as a DPI value (LogPixels): 96 = 100% (1x), up to 240 = 250%. Above 96 the
     /// Mac driver switches to native Retina pixels so the scaled UI stays crisp. Applied to the prefix
     /// registry on change. Supersedes the old on/off retinaMode (which was just 96 / 192).

--- a/Sources/HighballKit/Bottle.swift
+++ b/Sources/HighballKit/Bottle.swift
@@ -160,6 +160,11 @@ public struct BottleSettings: Codable, Sendable {
     public var dxvkAsync: Bool = true
     /// Cap the frame rate (0 = uncapped). Applied per renderer (DXVK_FRAME_RATE / DXMT_CONFIG).
     public var fpsCap: Int = 0
+    /// Map the Mac Command keys to Windows Ctrl, so Cmd+C/Cmd+V/Cmd+A do what a Mac user expects
+    /// inside Windows apps. Wine's default leaves Command as Alt, which is why pasting into Steam
+    /// beeps instead of pasting. Option is mapped to Alt alongside it — without that, mapping both
+    /// Command keys leaves no way to send Alt at all (winemac.drv warns about exactly this).
+    public var commandIsControl: Bool = true
     /// Windows UI scale as a DPI value (LogPixels): 96 = 100% (1x), up to 240 = 250%. Above 96 the
     /// Mac driver switches to native Retina pixels so the scaled UI stays crisp. Applied to the prefix
     /// registry on change. Supersedes the old on/off retinaMode (which was just 96 / 192).

--- a/Sources/HighballKit/BottleStore.swift
+++ b/Sources/HighballKit/BottleStore.swift
@@ -74,6 +74,7 @@ public struct BottleStore: Sendable {
         if windowsVersion != .win10 { try await runner.setWindowsVersion(windowsVersion) }
         try? await runner.setGpuIdentity()
         try? await runner.setServiceTimeout()
+        try? await runner.setKeyboardMapping(commandIsControl: bottle.settings.commandIsControl)
         return bottle
     }
 

--- a/Sources/HighballKit/WineRunner.swift
+++ b/Sources/HighballKit/WineRunner.swift
@@ -117,6 +117,7 @@ public struct WineRunner: Sendable {
     @discardableResult
     public func start(_ executable: URL, arguments: [String] = [], renderer: Renderer? = nil, extraEnvironment: [String: String] = [:], workingDirectory: URL? = nil, onOutput: (@Sendable (String) -> Void)? = nil) async throws -> LaunchResult {
         await syncDllOverridesRegistry()
+        await syncKeyboardRegistry()
         return try await run([executable.path] + arguments, renderer: renderer, extraEnvironment: extraEnvironment, label: executable.lastPathComponent, workingDirectory: workingDirectory, onOutput: onOutput)
     }
 
@@ -288,6 +289,18 @@ public struct WineRunner: Sendable {
             ("LeftCommandIsCtrl", on), ("RightCommandIsCtrl", on),
             ("LeftOptionIsAlt", on), ("RightOptionIsAlt", on),
         ]
+    }
+
+    /// Applies the Command→Ctrl mapping when it differs from what the prefix already has, so an
+    /// existing bottle picks it up on its next launch and the settings toggle takes effect without
+    /// a Repair. Same shape as syncDllOverridesRegistry.
+    public func syncKeyboardRegistry() async {
+        let current = bottle.settings.commandIsControl
+        guard current != bottle.settings.commandIsControlSynced else { return }
+        guard (try? await setKeyboardMapping(commandIsControl: current)) != nil else { return }
+        var copy = bottle
+        copy.settings.commandIsControlSynced = current
+        try? copy.save()
     }
 
     public func setKeyboardMapping(commandIsControl: Bool) async throws {

--- a/Sources/HighballKit/WineRunner.swift
+++ b/Sources/HighballKit/WineRunner.swift
@@ -271,6 +271,30 @@ public struct WineRunner: Sendable {
                          type: "REG_SZ", data: String(Self.servicesPipeTimeoutMs))
     }
 
+    /// Wine's Mac driver leaves the Command keys acting as Alt, so Cmd+C / Cmd+V reach Windows
+    /// apps as Alt+C / Alt+V — nothing pastes and macOS beeps. Mapping Command to Ctrl fixes
+    /// copy/paste everywhere (Steam's login and store pages are the common report).
+    ///
+    /// Option must be mapped to Alt in the same breath: with both Command keys taken, winemac.drv
+    /// itself warns "there is no way to send an Alt key to Windows applications", which would break
+    /// Alt-driven game bindings. The four values move together or not at all.
+    ///
+    /// Pure so the mapping is unit-tested without touching a prefix.
+    public static func keyboardRegistry(commandIsControl: Bool) -> [(name: String, data: String)] {
+        let on = commandIsControl ? "1" : "0"
+        return [
+            ("LeftCommandIsCtrl", on), ("RightCommandIsCtrl", on),
+            ("LeftOptionIsAlt", on), ("RightOptionIsAlt", on),
+        ]
+    }
+
+    public func setKeyboardMapping(commandIsControl: Bool) async throws {
+        for v in Self.keyboardRegistry(commandIsControl: commandIsControl) {
+            try await regAdd(key: #"HKCU\Software\Wine\Mac Driver"#, name: v.name,
+                             type: "REG_DWORD", data: v.data)
+        }
+    }
+
     public func setGpuIdentity() async throws {
         try await regAdd(key: #"HKCU\Software\Wine\Direct3D"#, name: "VideoPciVendorID", type: "REG_DWORD", data: String(Self.gpuIdentity.vendor))
         try await regAdd(key: #"HKCU\Software\Wine\Direct3D"#, name: "VideoPciDeviceID", type: "REG_DWORD", data: String(Self.gpuIdentity.device))

--- a/Sources/HighballKit/WineRunner.swift
+++ b/Sources/HighballKit/WineRunner.swift
@@ -281,7 +281,9 @@ public struct WineRunner: Sendable {
     ///
     /// Pure so the mapping is unit-tested without touching a prefix.
     public static func keyboardRegistry(commandIsControl: Bool) -> [(name: String, data: String)] {
-        let on = commandIsControl ? "1" : "0"
+        // Mac Driver settings are REG_SZ "y"/"n", not DWORD — a DWORD 1 is read as absent and the
+        // mapping silently stays off, which is exactly how this was first shipped and had to be fixed.
+        let on = commandIsControl ? "y" : "n"
         return [
             ("LeftCommandIsCtrl", on), ("RightCommandIsCtrl", on),
             ("LeftOptionIsAlt", on), ("RightOptionIsAlt", on),
@@ -291,7 +293,7 @@ public struct WineRunner: Sendable {
     public func setKeyboardMapping(commandIsControl: Bool) async throws {
         for v in Self.keyboardRegistry(commandIsControl: commandIsControl) {
             try await regAdd(key: #"HKCU\Software\Wine\Mac Driver"#, name: v.name,
-                             type: "REG_DWORD", data: v.data)
+                             type: "REG_SZ", data: v.data)
         }
     }
 

--- a/Sources/highball/main.swift
+++ b/Sources/highball/main.swift
@@ -180,6 +180,7 @@ struct Bottle: AsyncParsableCommand {
             let r = try await runner.wineboot()
             try? await runner.setGpuIdentity()
             try? await runner.setServiceTimeout()
+            try? await runner.setKeyboardMapping(commandIsControl: b.settings.commandIsControl)
             // Same 32-bit check the app and bottle creation use (#37): wineboot exits 0 even
             // when it skipped building syswow64, so the exit code alone means little.
             try await BottleStore.ensureWoW64(runner: runner, bottle: b, log: r.log)

--- a/Tests/HighballKitTests/RegressionTests.swift
+++ b/Tests/HighballKitTests/RegressionTests.swift
@@ -98,6 +98,17 @@ final class RegressionTests: XCTestCase {
                        "turning it off must clear the same keys it set, not leave half behind")
     }
 
+    // A bottle made before this setting existed decodes with commandIsControlSynced == nil, which
+    // is what makes the first launch after updating apply the mapping instead of waiting for Repair.
+    func testPreExistingBottleIsUnsyncedSoLaunchApplies() throws {
+        let json = #"{"formatVersion":1,"name":"old","engineID":"e"}"#
+        let s = try JSONDecoder().decode(BottleSettings.self, from: Data(json.utf8))
+        XCTAssertTrue(s.commandIsControl, "the default carries into bottles that predate it")
+        XCTAssertNil(s.commandIsControlSynced, "never mirrored → next launch applies it")
+        XCTAssertNotEqual(s.commandIsControl, s.commandIsControlSynced,
+                          "differing is the trigger syncKeyboardRegistry checks")
+    }
+
     // New bottles get Mac-native copy/paste; the setting is what the registry write follows.
     func testCommandIsControlDefaultsOn() throws {
         let s = BottleSettings(name: "t", engineID: "e")

--- a/Tests/HighballKitTests/RegressionTests.swift
+++ b/Tests/HighballKitTests/RegressionTests.swift
@@ -80,6 +80,28 @@ final class RegressionTests: XCTestCase {
         XCTAssertEqual(WineRunner.dpiRegistry(for: 999).retinaMode, "y")
     }
 
+    // Cmd+V beeped instead of pasting in Steam: Wine's Mac driver leaves Command acting as Alt.
+    // Mapping Command to Ctrl without also mapping Option to Alt leaves no way to send Alt at all
+    // (winemac.drv warns about exactly that), so the four values must move together.
+    func testCommandKeyMappingMovesAsASet() throws {
+        let on = WineRunner.keyboardRegistry(commandIsControl: true)
+        XCTAssertEqual(on.count, 4)
+        XCTAssertEqual(Set(on.map(\.name)),
+                       ["LeftCommandIsCtrl", "RightCommandIsCtrl", "LeftOptionIsAlt", "RightOptionIsAlt"])
+        XCTAssertTrue(on.allSatisfy { $0.data == "1" }, "Command→Ctrl is useless without Option→Alt")
+
+        let off = WineRunner.keyboardRegistry(commandIsControl: false)
+        XCTAssertTrue(off.allSatisfy { $0.data == "0" }, "off restores Wine's default mapping")
+        XCTAssertEqual(Set(off.map(\.name)), Set(on.map(\.name)),
+                       "turning it off must clear the same keys it set, not leave half behind")
+    }
+
+    // New bottles get Mac-native copy/paste; the setting is what the registry write follows.
+    func testCommandIsControlDefaultsOn() throws {
+        let s = BottleSettings(name: "t", engineID: "e")
+        XCTAssertTrue(s.commandIsControl, "Mac users expect ⌘C/⌘V to work in Windows apps")
+    }
+
     // Steam writes StateFlags 1026 while downloading; the game card must not offer Play.
     func testACFDownloadingNotReady() throws {
         let acf = """

--- a/Tests/HighballKitTests/RegressionTests.swift
+++ b/Tests/HighballKitTests/RegressionTests.swift
@@ -115,6 +115,51 @@ final class RegressionTests: XCTestCase {
         XCTAssertTrue(s.commandIsControl, "Mac users expect ⌘C/⌘V to work in Windows apps")
     }
 
+    // The exact bug from review: commandIsControl encoded but never decoded, so a bottle saved with
+    // the mapping off came back on after every relaunch and the toggle could not be turned off.
+    func testCommandIsControlOffSurvivesSaveAndLoad() throws {
+        var s = BottleSettings(name: "rt", engineID: "eng")
+        s.commandIsControl = false
+        s.commandIsControlSynced = false
+        let reloaded = try JSONDecoder.highball.decode(BottleSettings.self,
+                                                       from: try JSONEncoder.highball.encode(s))
+        XCTAssertFalse(reloaded.commandIsControl, "off must still be off after a reload")
+        XCTAssertEqual(reloaded.commandIsControlSynced, false,
+                       "synced must round-trip too, or every launch re-mirrors the registry")
+    }
+
+    // A settings field that isn't in the hand-written init(from:) encodes but never decodes,
+    // so it silently reverts to its default on the next load. Generic on purpose: this is the
+    // tripwire for the next setting anyone adds, not just for commandIsControl.
+    func testEverySettingSurvivesSaveAndLoad() throws {
+        var s = BottleSettings(name: "rt", engineID: "eng")
+        s.renderer = .wined3d
+        s.rendererExplicit = true
+        s.windowsVersion = .win11
+        s.sync = .esync
+        s.metalHUD = true
+        s.advertiseAVX = true
+        s.dxvkAsync = false
+        s.fpsCap = 60
+        s.dpiScale = 192
+        s.dllOverrides = "version=n,b"
+        s.dllOverridesSynced = "version=n,b"
+        s.dxvkAppConfig = ["a.exe": ["k": "v"]]
+        s.commandIsControl = false
+        s.commandIsControlSynced = false
+        s.environment = ["K": "V"]
+        s.pins = [Pin(name: "p", path: #"C:\g.exe"#)]
+        s.recipes = ["r"]
+
+        // Every value differs from its default, so a field the decoder forgot comes back as the
+        // default and the two encodings diverge on exactly that key.
+        let written = try JSONEncoder.highball.encode(s)
+        let reloaded = try JSONDecoder.highball.decode(BottleSettings.self, from: written)
+        XCTAssertEqual(String(data: written, encoding: .utf8),
+                       String(data: try JSONEncoder.highball.encode(reloaded), encoding: .utf8),
+                       "a settings field is missing its decodeIfPresent line in BottleSettings.init(from:)")
+    }
+
     // Steam writes StateFlags 1026 while downloading; the game card must not offer Play.
     func testACFDownloadingNotReady() throws {
         let acf = """

--- a/Tests/HighballKitTests/RegressionTests.swift
+++ b/Tests/HighballKitTests/RegressionTests.swift
@@ -83,15 +83,17 @@ final class RegressionTests: XCTestCase {
     // Cmd+V beeped instead of pasting in Steam: Wine's Mac driver leaves Command acting as Alt.
     // Mapping Command to Ctrl without also mapping Option to Alt leaves no way to send Alt at all
     // (winemac.drv warns about exactly that), so the four values must move together.
+    // Mac Driver values are REG_SZ "y"/"n". Writing DWORD 1 reads as absent and the mapping
+    // silently stays off — the first cut of this shipped that way.
     func testCommandKeyMappingMovesAsASet() throws {
         let on = WineRunner.keyboardRegistry(commandIsControl: true)
         XCTAssertEqual(on.count, 4)
         XCTAssertEqual(Set(on.map(\.name)),
                        ["LeftCommandIsCtrl", "RightCommandIsCtrl", "LeftOptionIsAlt", "RightOptionIsAlt"])
-        XCTAssertTrue(on.allSatisfy { $0.data == "1" }, "Command→Ctrl is useless without Option→Alt")
+        XCTAssertTrue(on.allSatisfy { $0.data == "y" }, "Command→Ctrl is useless without Option→Alt")
 
         let off = WineRunner.keyboardRegistry(commandIsControl: false)
-        XCTAssertTrue(off.allSatisfy { $0.data == "0" }, "off restores Wine's default mapping")
+        XCTAssertTrue(off.allSatisfy { $0.data == "n" }, "off restores Wine's default mapping")
         XCTAssertEqual(Set(off.map(\.name)), Set(on.map(\.name)),
                        "turning it off must clear the same keys it set, not leave half behind")
     }


### PR DESCRIPTION
## What this changes

First time I used Highball I couldn't log into Steam — ⌘V did nothing in the password
field, it just beeped. I assumed the clipboard was broken. It isn't: Wine's Mac driver
leaves Command acting as Alt, so ⌘V arrives as Alt+V. Ctrl+V works, but nothing in the app
or README says so.

Adds a `commandIsControl` bottle setting (default on) that maps the Command keys to Ctrl.
Option moves to Alt in the same write — with both Command keys taken, winemac.drv warns
there is "no way to send an Alt key to Windows applications", so the four values move
together. Written as `REG_SZ "y"`, following the existing `RetinaMode` pattern. No Wine
patch.

Applied at creation, Repair, CLI, and on launch when it differs — otherwise an existing
bottle would need a Repair nobody would think to press. Plus a settings toggle and a README
line, since the keyboard wasn't documented at all.

**Trade-off:** Option becomes Alt, so it no longer composes Mac special characters inside
Windows apps. Dedicated and dead keys are unaffected — `ñ` still types on a Latin American
layout. On a US layout, Option+n+n does not produce `ñ` in a Wine app with this on; I did
not check whether it worked before the change. The toggle turns the whole thing off.

## How it was verified

Steam on M4 / macOS 26.5.2: ⌘C, ⌘V and ⌘A work in the login and store fields, and ⌘C out
of a Windows app lands in the Mac clipboard.

- [x] `swift build` passes locally — `swift test` can't run here (`no such module 'XCTest'`,
      Command Line Tools without Xcode.app; fails the same on `main`), so the two new tests
      are unverified and need CI
- [x] Game results and recipes go to [highball-db](https://github.com/gauthierpiarrette/highball-db), not this repo