### PR TITLE
WineRunner: record sync markers without rewriting the whole snapshot

### DIFF
--- a/Sources/HighballKit/Paths.swift
+++ b/Sources/HighballKit/Paths.swift
@@ -258,13 +258,26 @@ public enum BugReport {
             (try? $0.resourceValues(forKeys: key))?.contentModificationDate ?? .distantPast
         }
         let newestFirst = logs.sorted { modified($0) > modified($1) }.prefix(maxLogsExamined)
+        // A wineboot log is the prefix booting, and it ends before the game starts, so it can
+        // never show a game failing. It nonetheless matches a backend marker, because wineboot
+        // creates a d3d adapter and Wine shouts `wined3d_adapter_create` while doing it — so the
+        // marker test alone ranked it "informative". In issue #21 the reporter sent one twice,
+        // both times chosen by this picker, and each round cost days. Repair runs wineboot, so it
+        // is also the log most likely to be the newest one after someone follows fix instructions.
+        let isPrefixBoot: (URL) -> Bool = { $0.lastPathComponent.hasSuffix("-wineboot.log") }
         var fallback: (url: URL, text: String)?
+        var bootFallback: (url: URL, text: String)?
         for url in newestFirst {
             guard let text = boundedText(of: url) else { continue }
+            if isPrefixBoot(url) {
+                if bootFallback == nil { bootFallback = (url, text) }
+                continue
+            }
             if backendMarkers.contains(where: text.contains) { return (url, text) }
             if fallback == nil { fallback = (url, text) }
         }
-        return fallback
+        // Only when it is genuinely the only thing on disk — a bottle that has never run anything.
+        return fallback ?? bootFallback
     }
 
     public static func url(version: String, paths: HighballPaths = HighballPaths()) -> URL {

--- a/Sources/HighballKit/WineRunner.swift
+++ b/Sources/HighballKit/WineRunner.swift
@@ -286,9 +286,17 @@ public struct WineRunner: Sendable {
             if status != 0 { allAdded = false }
         }
         guard allAdded else { return }
-        var copy = bottle
-        copy.settings.dllOverridesSynced = current
-        try? copy.save()
+        markSynced { $0.dllOverridesSynced = current }
+    }
+
+    /// Records a "last mirrored into the prefix registry" marker. Re-reads from disk rather than
+    /// saving `bottle`, which is a snapshot taken when the runner was built: saving it whole also
+    /// rewrites every other setting as it stood then, so a second sync in the same launch would
+    /// revert the marker the first one just wrote.
+    private func markSynced(_ apply: (inout BottleSettings) -> Void) {
+        guard var fresh = try? Bottle.load(bottle.url) else { return }
+        apply(&fresh.settings)
+        try? fresh.save()
     }
 
     /// Windows UI scaling. LogPixels is the Windows system DPI (96 = 100%, 240 = 250%): DPI-aware

--- a/Tests/HighballKitTests/RegressionTests.swift
+++ b/Tests/HighballKitTests/RegressionTests.swift
@@ -157,6 +157,53 @@ extension RegressionTests {
     // backwards: Wine gives the whole process tree one pipe, so the game's DXVK output lands in
     // the steam.exe log, and skipping it left a wineboot log with nothing in it. That is the
     // file issue #21's reporter sent, and it cost four rounds. Selection is now by content.
+    /// Issue #21: the reporter sent a `-wineboot.log` twice, both times chosen by this picker,
+    /// and each round cost days. A wineboot log is the prefix booting and ends before the game
+    /// starts, so it can never show a game failing — but it matches a backend marker anyway,
+    /// because wineboot creates a d3d adapter and Wine shouts `wined3d_adapter_create`.
+    func testReportSkipsAPrefixBootLogWhenAnythingElseExists() throws {
+        let home = FileManager.default.temporaryDirectory.appending(path: "hb-boot-\(UUID().uuidString)")
+        let paths = HighballPaths(home: home)
+        try paths.ensure()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        // Where legacy CS:GO's output actually lands: the launcher's log, written before the
+        // Repair that follows a fix instruction — so the boot log is the newer of the two.
+        let game = paths.logs.appending(path: "2026-08-29T210000Z-CS-steam.exe.log")
+        try ["# gin E bottle=CS renderer=dxvk", "info:  DXVK-Kegworks: v1.10.4-async",
+             "info:  Game: csgo.exe", "Initializing game data", "# exit=0 (ok) after 300s"]
+            .joined(separator: "\n").write(to: game, atomically: true, encoding: .utf8)
+        let boot = paths.logs.appending(path: "2026-08-29T211442Z-CS-wineboot.log")
+        try ["# gin E bottle=CS renderer=dxvk", "# wine wineboot -u",
+             "01b4:err:winediag:wined3d_adapter_create Using the Vulkan renderer for d3d10/11 applications.",
+             "# exit=0 (ok) after 12s"]
+            .joined(separator: "\n").write(to: boot, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: Date().addingTimeInterval(-600)],
+                                              ofItemAtPath: game.path)
+        try FileManager.default.setAttributes([.modificationDate: Date()], ofItemAtPath: boot.path)
+
+        let body = BugReport.url(version: "0.7.17", paths: paths).absoluteString.removingPercentEncoding ?? ""
+        XCTAssertTrue(body.contains("DXVK-Kegworks"), "the game's own output must be attached")
+        XCTAssertFalse(body.contains("wineboot -u"), "a prefix-boot log must never win over a real log")
+    }
+
+    /// But a bottle that has only ever booted still has something worth sending.
+    func testReportStillAttachesABootLogWhenItIsTheOnlyOne() throws {
+        let home = FileManager.default.temporaryDirectory.appending(path: "hb-boot1-\(UUID().uuidString)")
+        let paths = HighballPaths(home: home)
+        try paths.ensure()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try ["# gin E bottle=CS renderer=dxvk", "# wine wineboot -u",
+             "01b4:err:winediag:wined3d_adapter_create Using the Vulkan renderer",
+             "# exit=53 (failed) after 12s"]
+            .joined(separator: "\n")
+            .write(to: paths.logs.appending(path: "2026-08-29T211442Z-CS-wineboot.log"),
+                   atomically: true, encoding: .utf8)
+
+        let body = BugReport.url(version: "0.7.17", paths: paths).absoluteString.removingPercentEncoding ?? ""
+        XCTAssertTrue(body.contains("wineboot -u"), "with nothing else on disk it is still the best evidence")
+    }
+
     func testReportPicksTheLogThatNamesTheBackendEvenWhenItIsALaunchers() throws {
         let dir = FileManager.default.temporaryDirectory.appending(path: "hb-report-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)


### PR DESCRIPTION
Latent today, not a live bug.

`WineRunner.bottle` is a snapshot taken when the runner is built. `syncDllOverridesRegistry` records that it mirrored the overrides into the prefix registry by saving that snapshot whole, which also rewrites every other setting as it stood at construction time.

That is harmless while `start()` runs exactly one sync, which is the case on main. Add a second and its save reverts the marker the first just wrote, so the mirroring from #22/#25 re-runs on every launch instead of once.

#39 adds a second sync, so landing this first means the bug never exists in a shipped build and that PR keeps its call site to one line.

Re-reads from disk and touches only the marker. No behaviour change on main. 93 tests pass.