### PR TITLE
README: add the Homebrew install line

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ so you can check whether your game runs before downloading a byte.
 macOS 14+, notarized. Drag it to Applications and open it. The app walks you through the
 rest: engine download, your first bottle, Steam.
 
+Or with Homebrew:
+
+```sh
+brew install --cask gauthierpiarrette/highball/highball
+```
+
 Not sure it'll run your game? **[Check the compatibility database →](https://gethighball.com/database/)**
 
 > **Beta, working end to end:** engine install → bottle → Steam login → game, with


### PR DESCRIPTION
Adds `brew install --cask gauthierpiarrette/highball/highball` to the Download section.

The cask lives in the new tap [gauthierpiarrette/homebrew-highball](https://github.com/gauthierpiarrette/homebrew-highball). Its CI runs `brew style`, `brew audit --cask --online --strict`, and a real install/uninstall on an arm64 macOS 15 runner, asserting the installed bundle is signed by B95M7DARU4 and notarized. That passed on 0.7.18.

The tap self-bumps hourly from the latest release, so it will not go stale between releases.