### PR TITLE
verify-game: correct the reported-upstream definition

### DIFF
--- a/.claude/skills/verify-game/SKILL.md
+++ b/.claude/skills/verify-game/SKILL.md
@@ -61,9 +61,15 @@ Pick the status by what was actually observed:
 | status | means |
 |---|---|
 | `verified-local` | someone ran it here, start to finish |
-| `reported-upstream` | tested and known broken, with the cause recorded |
+| `reported-upstream` | named in DXMT release notes as working or fixed; not verified here |
 | `community` | reported by users, unverified by us |
 | `blocked-anticheat` | cannot work, anti-cheat |
+
+There is deliberately no status for "we tested it here and it does not work". Do not stretch
+`reported-upstream` to mean that, and do not invent a status: record the failure in `notes`
+and `knownIssues`, leave the status at what is actually true, and raise the gap with the
+maintainer. `reported-upstream` is defined by the site build (`Scripts/build-site.py`), and
+changing what it means silently changes what every existing entry claims.
 
 `lastVerified` carries date, engine id, macOS version, and chip, because the answer differs
 across all four. Notes say what to do, what it costs, and what still fails.


### PR DESCRIPTION
The status table in \`verify-game/SKILL.md\` defined \`reported-upstream\` as "tested and known broken, with the cause recorded".

The database means close to the opposite. [\`Scripts/build-site.py\`](https://github.com/gauthierpiarrette/highball-db/blob/main/Scripts/build-site.py) defines it as *"Named in DXMT release notes as working or fixed; not yet verified by Highball."* Anyone following the skill as written would have marked a broken game with a status the site renders as working-upstream.

This corrects the definition and names the gap it was papering over: there is no status meaning "we tested it here and it does not work". The skill now says to record that in `notes`/`knownIssues` and raise it, rather than stretching an existing status.

That gap is about to matter for [highball-db#7](https://github.com/gauthierpiarrette/highball-db/issues/7) (Sims Legacy Collection), which may become the first entry that needs it.

`claude plugin validate` passes.