### PR TITLE
wineboot: set the real .NET mscoree aside for the boot so Repair no longer hangs

### DIFF
--- a/Sources/HighballKit/WineRunner.swift
+++ b/Sources/HighballKit/WineRunner.swift
@@ -94,9 +94,14 @@ public struct WineRunner: Sendable {
         extraEnvironment: [String: String] = [:],
         label: String? = nil,
         workingDirectory: URL? = nil,
+        restoreMscoreeFirst: Bool = true,
         onOutput: (@Sendable (String) -> Void)? = nil
     ) async throws -> LaunchResult {
         try paths.ensure()
+        // A boot that died halfway would leave the bottle's real .NET shim set aside (see
+        // setAsideForeignMscoree); put it back before anything runs in this prefix. The boot
+        // itself is the one launch that must not, since it just set the file aside on purpose.
+        if restoreMscoreeFirst { Self.restoreMscoree(bottle: bottle) }
         // DXVK reads its options from the generated conf (async toggle + per-game profiles like
         // [csgo.exe], issue #21) — refresh it before the spawn. Every renderer but wined3d gets
         // DXVK's d3d9 attached, so every one of them needs the conf, not just .dxvk.
@@ -212,8 +217,79 @@ public struct WineRunner: Sendable {
 
     /// `force` adds -f: re-runs the inf installs even when the prefix looks current, which is
     /// how a prefix missing its 32-bit half gets a second chance (issue #37).
+    /// Suffix of a `mscoree.dll` set aside for the duration of a `wineboot` run.
+    public static let asideSuffix = ".highball-wineboot"
+
+    /// The bottle's two `mscoree.dll` copies and the engine builtin each would be on a Wine-made
+    /// prefix, as (bottle file, engine file) pairs.
+    static func mscoreePairs(engine: InstalledEngine, bottle: Bottle) -> [(URL, URL)] {
+        [("windows/system32/mscoree.dll", "lib/wine/x86_64-windows/mscoree.dll"),
+         ("windows/syswow64/mscoree.dll", "lib/wine/i386-windows/mscoree.dll")].map {
+            (bottle.driveC.appending(path: $0.0), engine.engineDir.appending(path: $0.1))
+        }
+    }
+
+    /// Whether the bottle carries Microsoft's .NET shim rather than Wine's `mscoree.dll`, which
+    /// is what the dotnet48 recipe leaves behind. A Wine-made prefix holds byte copies of the
+    /// engine builtins, so a size mismatch on either copy is the tell.
+    public static func hasForeignMscoree(engine: InstalledEngine, bottle: Bottle) -> Bool {
+        mscoreePairs(engine: engine, bottle: bottle).contains { pair in
+            guard let a = try? FileManager.default.attributesOfItem(atPath: pair.0.path)[.size] as? UInt64,
+                  let b = try? FileManager.default.attributesOfItem(atPath: pair.1.path)[.size] as? UInt64 else { return false }
+            return a != b
+        }
+    }
+
+    /// Moves a foreign `mscoree.dll` (both halves) aside for a boot; `restoreMscoree` puts it back.
+    ///
+    /// `wineboot -u` re-runs wine.inf's setup sections, which call `DllRegisterServer` on a fixed
+    /// list of DLLs, `mscoree.dll` among them. In a bottle where the dotnet48 recipe installed
+    /// Microsoft's .NET Framework that file is the real .NET shim, the registry marks it native,
+    /// and the shim's registration loads the CLR and never returns under wow64: wineboot waits
+    /// on the 32-bit rundll32 forever. Reproduced 2026-09-03 on the Gaming bottle (real .NET 4.8
+    /// + Steam): Repair and the engine-update wineboot hang at `do_register_dll ... mscoree.dll`,
+    /// on two engines, with and without leftover processes. Fresh bottles boot fine.
+    ///
+    /// The tools one would reach for first do not work. A `mscoree=b` override makes Wine's
+    /// mscoree register, which calls `mscorwks.DllRegisterServerInternal`; the real mscorwks
+    /// has no such export and Wine aborts the process into a debugger. A `mscoree=d` override is
+    /// honoured by the 64-bit half and ignored by 32-bit processes under wow64 (the trace shows
+    /// them loading the real file as native regardless). And wineboot's inf comes from ntdll's
+    /// own data directory, so a filtered wine.inf cannot be pointed at through `WINEDATADIR`.
+    ///
+    /// With the file absent, both halves fail to load it (the native-only override rules out a
+    /// builtin fallback), setupapi records one `could not load` and continues, and the boot
+    /// completes: 15 s where it used to hang. The inf's fake-DLL step drops Wine's mscoree into
+    /// the gap meanwhile, which is why the restore overwrites rather than checks. The real
+    /// installer already registered the runtime, so skipping that one entry loses nothing.
+    public static func setAsideForeignMscoree(engine: InstalledEngine, bottle: Bottle) throws -> Bool {
+        guard hasForeignMscoree(engine: engine, bottle: bottle) else { return false }
+        for (file, _) in mscoreePairs(engine: engine, bottle: bottle) where FileManager.default.fileExists(atPath: file.path) {
+            let aside = URL(fileURLWithPath: file.path + asideSuffix)
+            try? FileManager.default.removeItem(at: aside)
+            try FileManager.default.moveItem(at: file, to: aside)
+        }
+        return true
+    }
+
+    /// Puts back any `mscoree.dll` set aside by `setAsideForeignMscoree`, overwriting whatever the
+    /// boot left in its place. Safe to call when nothing is aside. Also run before every launch,
+    /// so a boot that died halfway (crash, force quit) cannot leave the bottle without its .NET.
+    public static func restoreMscoree(bottle: Bottle) {
+        for dir in ["windows/system32", "windows/syswow64"] {
+            let file = bottle.driveC.appending(path: "\(dir)/mscoree.dll")
+            let aside = URL(fileURLWithPath: file.path + asideSuffix)
+            guard FileManager.default.fileExists(atPath: aside.path) else { continue }
+            try? FileManager.default.removeItem(at: file)
+            try? FileManager.default.moveItem(at: aside, to: file)
+        }
+    }
+
     public func wineboot(force: Bool = false) async throws -> LaunchResult {
-        try await run(["wineboot", force ? "-fu" : "-u"], renderer: .wined3d, label: "wineboot")
+        let aside = try Self.setAsideForeignMscoree(engine: engine, bottle: bottle)
+        defer { if aside { Self.restoreMscoree(bottle: bottle) } }
+        return try await run(["wineboot", force ? "-fu" : "-u"], renderer: .wined3d, label: "wineboot",
+                             restoreMscoreeFirst: false)
     }
 
     public func kill() throws {

--- a/Tests/HighballKitTests/RegressionTests.swift
+++ b/Tests/HighballKitTests/RegressionTests.swift
@@ -527,6 +527,61 @@ extension RegressionTests {
 
     // The alert used to edit `selectedBottle`, which launchGame never sets, so accepting a
     // suggestion could rewrite an unrelated bottle. The cycle itself must stay total.
+    // A bottle with Microsoft's .NET Framework (dotnet48 recipe) hangs every `wineboot -u`:
+    // wine.inf's 32-bit setup registers mscoree.dll, the registry marks it native, and the real
+    // shim's DllRegisterServer never returns under wow64 (Repair and engine updates both hang,
+    // reproduced 2026-09-03; overrides and a filtered inf were tried and do not work, see
+    // WineRunner.setAsideForeignMscoree). The boot runs with the real file set aside and
+    // restores it afterwards, overwriting what the boot dropped in the gap. A bottle whose
+    // mscoree is the engine's own file is left alone, and a launch after a boot that died
+    // halfway restores the file before running anything.
+    func testWinebootSetsAsideForeignMscoreeAndRestoresIt() throws {
+        let manifest = try EngineManifest.load(from: URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .appending(path: "spike/engine-manifest.json"))
+        let root = FileManager.default.temporaryDirectory.appending(path: "hb-boot-\(UUID().uuidString)")
+        let bottleURL = FileManager.default.temporaryDirectory.appending(path: "hb-boot-bottle-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root); try? FileManager.default.removeItem(at: bottleURL) }
+        let fm = FileManager.default
+        for dir in ["engine/lib/wine/x86_64-windows", "engine/lib/wine/i386-windows"] {
+            try fm.createDirectory(at: root.appending(path: dir), withIntermediateDirectories: true)
+            try Data(repeating: 0, count: 100).write(to: root.appending(path: "\(dir)/mscoree.dll"))
+        }
+        let sys32 = bottleURL.appending(path: "drive_c/windows/system32")
+        let wow64 = bottleURL.appending(path: "drive_c/windows/syswow64")
+        try fm.createDirectory(at: sys32, withIntermediateDirectories: true)
+        try fm.createDirectory(at: wow64, withIntermediateDirectories: true)
+        let engine = InstalledEngine(manifest: manifest, root: root)
+        let bottle = Bottle(url: bottleURL, settings: BottleSettings(name: "t", engineID: manifest.id))
+
+        // Wine's own files (same size as the engine's): nothing happens.
+        try Data(repeating: 0, count: 100).write(to: sys32.appending(path: "mscoree.dll"))
+        try Data(repeating: 0, count: 100).write(to: wow64.appending(path: "mscoree.dll"))
+        XCTAssertFalse(WineRunner.hasForeignMscoree(engine: engine, bottle: bottle))
+        XCTAssertFalse(try WineRunner.setAsideForeignMscoree(engine: engine, bottle: bottle))
+        XCTAssertTrue(fm.fileExists(atPath: wow64.appending(path: "mscoree.dll").path))
+
+        // Microsoft's shim (a different file) in the 32-bit half only: both copies go aside.
+        let real = Data(repeating: 7, count: 300)
+        try real.write(to: wow64.appending(path: "mscoree.dll"))
+        XCTAssertTrue(WineRunner.hasForeignMscoree(engine: engine, bottle: bottle))
+        XCTAssertTrue(try WineRunner.setAsideForeignMscoree(engine: engine, bottle: bottle))
+        XCTAssertFalse(fm.fileExists(atPath: wow64.appending(path: "mscoree.dll").path))
+        XCTAssertFalse(fm.fileExists(atPath: sys32.appending(path: "mscoree.dll").path))
+        XCTAssertTrue(fm.fileExists(atPath: wow64.appending(path: "mscoree.dll" + WineRunner.asideSuffix).path))
+
+        // The boot drops Wine's copy into the gap; the restore overwrites it with the real one.
+        try Data(repeating: 0, count: 100).write(to: wow64.appending(path: "mscoree.dll"))
+        WineRunner.restoreMscoree(bottle: bottle)
+        XCTAssertEqual(try Data(contentsOf: wow64.appending(path: "mscoree.dll")), real)
+        XCTAssertTrue(fm.fileExists(atPath: sys32.appending(path: "mscoree.dll").path))
+        XCTAssertFalse(fm.fileExists(atPath: wow64.appending(path: "mscoree.dll" + WineRunner.asideSuffix).path))
+
+        // Nothing aside: restore is a no-op and leaves the files alone.
+        WineRunner.restoreMscoree(bottle: bottle)
+        XCTAssertEqual(try Data(contentsOf: wow64.appending(path: "mscoree.dll")), real)
+    }
+
     func testRendererSuggestionCyclesAndNeverSuggestsItself() {
         for r in Renderer.allCases {
             XCTAssertNotEqual(Renderer.suggestion(after: r), r)


### PR DESCRIPTION
Fixes #49. Details, the three approaches that do not work, and the verification are in the issue and the commit message. The regression test covers detection, set-aside, restore-overwrites, and the no-op cases on temp directories; the live proof is the Gaming bottle repairing in 20 s where it hung for over 40 minutes.